### PR TITLE
Hotfix for native SafeFrame rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "prebid-universal-creative",
-    "version": "1.16.0",
+    "version": "1.16.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "prebid-universal-creative",
-            "version": "1.16.0-pre",
+            "version": "1.16.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "babel-plugin-transform-object-assign": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "prebid-universal-creative",
-    "version": "1.16.0",
+    "version": "1.16.1",
     "description": "Universal creative for Prebid apps",
     "main": "dist/creative.js",
     "scripts": {
@@ -71,9 +71,9 @@
         "string-replace-webpack-plugin": "^0.1.3",
         "webdriverio": "^7.25.2",
         "webpack": "^3.12.0",
+        "webpack-common-shake": "^1.0.0",
         "webpack-stream": "^4.0.0",
-        "yargs": "^11.0.0",
-        "webpack-common-shake": "^1.0.0"
+        "yargs": "^11.0.0"
     },
     "dependencies": {
         "babel-plugin-transform-object-assign": "^6.22.0",

--- a/src/nativeAssetManager.js
+++ b/src/nativeAssetManager.js
@@ -7,6 +7,7 @@ import { addNativeClickTrackers, fireNativeImpressionTrackers } from './nativeOR
 import { sendRequest, loadScript } from './utils';
 import {prebidMessenger} from './messaging.js';
 import { isSafeFrame } from './environment.js';
+// import {runDynamicRenderer} from './dynamicRenderer.js';
 /*
  * Native asset->key mapping from Prebid.js/src/constants.json
  * https://github.com/prebid/Prebid.js/blob/8635c91942de9df4ec236672c39b19448545a812/src/constants.json#L67
@@ -255,7 +256,7 @@ export function newNativeAssetManager(win, nativeTag, mkMessenger = prebidMessen
       assets,
     };
 
-    return sendMessage(message, replaceAssets);
+    return sendMessage(message, replaceAssets(adId));
   }
 
   /*
@@ -268,7 +269,7 @@ export function newNativeAssetManager(win, nativeTag, mkMessenger = prebidMessen
       action: 'allAssetRequest',
       adId,
     };
-    return sendMessage(message, replaceAssets);
+    return sendMessage(message, replaceAssets(adId));
   }
 
   /*
@@ -285,116 +286,133 @@ export function newNativeAssetManager(win, nativeTag, mkMessenger = prebidMessen
     sendMessage(message);
   }
 
-  /*
-   * Postmessage listener for when Prebid responds with requested native assets.
-   */
-  function replaceAssets(event) {
-    try {
 
-      var data = {};
-
+  function replaceAssets(adId) {
+    return function(event) {
       try {
-        data = JSON.parse(event.data);
-      } catch (e) {
-        if (errorCountEscapeHatch++ > 10) {
-          // TODO: this should be a timeout, not an arbitrary cap on the number of messages received
-          /*
-           * if for some reason Prebid never responds with the native assets,
-           * get rid of this listener because other messages won't stop coming
-           */
-          stopListening();
-          throw e;
-        }
-        return;
-      }
 
-    if (data.message === 'assetResponse') {
-      // add GAM %%CLICK_URL_UNESC%% to the data object to be eventually used in renderers
-      data.clickUrlUnesc = clickUrlUnesc;
-      const body = win.document.body.innerHTML;
-      const head = win.document.head.innerHTML;
+        var data = {};
 
-        if (hasPbNativeData() && data.adId !== win.pbNativeData.adId) return;
-
-        callback = ((cb) => {
-          return () => {
-            fireNativeImpressionTrackers(data.adId, sendMessage);
-            addNativeClickTrackers(data.adId, sendMessage);
-            cb && cb();
+        try {
+          data = JSON.parse(event.data);
+        } catch (e) {
+          if (errorCountEscapeHatch++ > 10) {
+            // TODO: this should be a timeout, not an arbitrary cap on the number of messages received
+            /*
+             * if for some reason Prebid never responds with the native assets,
+             * get rid of this listener because other messages won't stop coming
+             */
+            stopListening();
+            throw e;
           }
-        })(callback);
-
-        if (head) win.document.head.innerHTML = replace(head, data);
-
-
-        data.assets = data.assets || [];
-        let renderPayload = data.assets;
-        if (data.ortb) {
-          renderPayload.ortb = data.ortb;
+          return;
         }
 
-        if ((data.hasOwnProperty('rendererUrl') && data.rendererUrl) || (hasPbNativeData() && win.pbNativeData.hasOwnProperty('rendererUrl'))) {
-          if (win.renderAd) {
-            const newHtml = (win.renderAd && win.renderAd(renderPayload)) || '';
+        if (data.message === 'assetResponse' && data.adId === adId) {
+          // if(data.renderer && parseInt(data.rendererVersion, 10) >= 2) {
+          //   // only use renderer if it declares version > 2
+          //   // see https://github.com/prebid/Prebid.js/pull/12655
+          //   runDynamicRenderer(adId, data, sendMessage, win);
+          //   return;
+          // }
+
+          // add GAM %%CLICK_URL_UNESC%% to the data object to be eventually used in renderers
+          data.clickUrlUnesc = clickUrlUnesc;
+          const body = win.document.body.innerHTML;
+          const head = win.document.head.innerHTML;
+
+          callback = ((cb) => {
+            return () => {
+              fireNativeImpressionTrackers(data.adId, sendMessage);
+              addNativeClickTrackers(data.adId, sendMessage);
+              cb && cb();
+            }
+          })(callback);
+
+          if (head) win.document.head.innerHTML = replace(head, data);
+
+
+          data.assets = data.assets || [];
+          let renderPayload = data.assets;
+          if (data.ortb) {
+            renderPayload.ortb = data.ortb;
+          }
+
+          // if there's a rendererUrl, we need to check whether it's already been loaded.
+          // There are 3 scenarios:
+          //   1) it's already been loaded (window.renderAd is present)
+          //   2) it is currently being loaded (through a script tag with id "pb-native-renderer")
+          //   3) it hasn't been loaded yet
+          //  1 and 2 seem intended to work with logic in nativeRenderManager.js, which (sometimes) loads rendererUrl through a <script id="pb-native-renderer">, but they could conceivably be used in an undocumented way to embed renderer logic directly in the creative.
+          if ((data.hasOwnProperty('rendererUrl') && data.rendererUrl) || (hasPbNativeData() && win.pbNativeData.hasOwnProperty('rendererUrl'))) {
+            if (win.renderAd) {
+              const newHtml = (win.renderAd && win.renderAd(renderPayload)) || '';
+
+              renderAd(newHtml, data);
+            } else if (document.getElementById('pb-native-renderer')) {
+              document.getElementById('pb-native-renderer').addEventListener('load', function () {
+                const newHtml = (win.renderAd && win.renderAd(renderPayload)) || '';
+
+                renderAd(newHtml, data);
+              });
+            } else {
+              loadScript(win, ((hasPbNativeData() && win.pbNativeData.hasOwnProperty('rendererUrl') && win.pbNativeData.rendererUrl) || data.rendererUrl), function () {
+                const newHtml = (win.renderAd && win.renderAd(renderPayload)) || '';
+
+                renderAd(newHtml, data);
+              });
+            }
+          } else if ((data.hasOwnProperty('adTemplate') && data.adTemplate) || (hasPbNativeData() && win.pbNativeData.hasOwnProperty('adTemplate'))) {
+            const template = (hasPbNativeData() && win.pbNativeData.hasOwnProperty('adTemplate') && win.pbNativeData.adTemplate) || data.adTemplate;
+            const newHtml = replace(template, data);
 
             renderAd(newHtml, data);
-          } else if (document.getElementById('pb-native-renderer')) {
-            document.getElementById('pb-native-renderer').addEventListener('load', function () {
-              const newHtml = (win.renderAd && win.renderAd(renderPayload)) || '';
-
-              renderAd(newHtml, data);
-            });
           } else {
-            loadScript(win, ((hasPbNativeData() && win.pbNativeData.hasOwnProperty('rendererUrl') && win.pbNativeData.rendererUrl) || data.rendererUrl), function () {
-              const newHtml = (win.renderAd && win.renderAd(renderPayload)) || '';
+            const newHtml = replace(body, data);
 
-              renderAd(newHtml, data);
-            });
+            win.document.body.innerHTML = newHtml;
+            callback && callback(); // all the other scenarios hit the callback via renderAd()
+            stopListening();
           }
-        } else if ((data.hasOwnProperty('adTemplate') && data.adTemplate) || (hasPbNativeData() && win.pbNativeData.hasOwnProperty('adTemplate'))) {
-          const template = (hasPbNativeData() && win.pbNativeData.hasOwnProperty('adTemplate') && win.pbNativeData.adTemplate) || data.adTemplate;
-          const newHtml = replace(template, data);
-
-          renderAd(newHtml, data);
-        } else {
-          const newHtml = replace(body, data);
-
-          win.document.body.innerHTML = newHtml;
-          callback && callback();
-          stopListening();
         }
+      } catch (e) {
+        errCallback && errCallback(e);
       }
-    } catch (e) {
-      errCallback && errCallback(e);
     }
   }
 
   /** This function returns the element that contains the current iframe. */
   function getCurrentFrameContainer(win) {
-    let currentWindow = win;
-    let currentParentWindow;
+    try {
+      let currentWindow = win;
+      let currentParentWindow;
 
-    while (currentWindow !== win.top) {
+      while (currentWindow !== win.top) {
         currentParentWindow = currentWindow.parent;
         if (!currentParentWindow.frames || !currentParentWindow.frames.length) return null;
         for (let idx = 0; idx < currentParentWindow.frames.length; idx++)
-            if (currentParentWindow.frames[idx] === currentWindow) {
-              if (!currentParentWindow.document) return null;
-                for (let frameElement of currentParentWindow.document.getElementsByTagName('iframe')) {
-                    if (!frameElement.contentWindow) return null;
-                    if (frameElement.contentWindow === currentWindow) {
-                        return frameElement.parentElement;
-                    }
-                }
+          if (currentParentWindow.frames[idx] === currentWindow) {
+            if (!currentParentWindow.document) return null;
+            for (let frameElement of currentParentWindow.document.getElementsByTagName('iframe')) {
+              if (!frameElement.contentWindow) return null;
+              if (frameElement.contentWindow === currentWindow) {
+                return frameElement.parentElement;
+              }
             }
+          }
+      }
+    } catch (e) {
+      // parent is cross-frame
     }
-}
+  }
 
   function renderAd(html, bid) {
     // if the current iframe is not a safeframe, try to set the
     // current iframe width to the width of the container. This
     // is to handle the case where the native ad is rendered inside
     // a GAM display ad.
+
+    // NOTE: this may be unnecessary, see https://github.com/prebid/prebid-universal-creative/issues/253.
     if (!isSafeFrame(window)) {
       let iframeContainer = getCurrentFrameContainer(win);
       if (iframeContainer && iframeContainer.children && iframeContainer.children[0]) {
@@ -411,9 +429,12 @@ export function newNativeAssetManager(win, nativeTag, mkMessenger = prebidMessen
 
     win.document.body.innerHTML += html;
     callback && callback();
-    win.removeEventListener('message', replaceAssets);
     stopListening();
-    const resize = () => requestHeightResize(bid.adId, (document.body.clientHeight || document.body.offsetHeight), document.body.clientWidth);
+    const resize = () => requestHeightResize(
+        bid.adId,
+        (document.body.clientHeight || document.body.offsetHeight),
+        document.body.clientWidth > 1 ? document.body.clientWidth : undefined
+    );
     document.readyState === 'complete' ? resize() : window.onload = resize;
 
     if (typeof window.postRenderAd === 'function') {

--- a/test/spec/nativeAssetManager_spec.js
+++ b/test/spec/nativeAssetManager_spec.js
@@ -90,7 +90,7 @@ function generateRenderer(assets) {
 }
 
 describe('nativeAssetManager', () => {
-  let win;
+  let win, sandbox;
 
   function makeManager(args, mkMessenger = prebidMessenger) {
     return newNativeAssetManager(win, {
@@ -101,6 +101,11 @@ describe('nativeAssetManager', () => {
 
   beforeEach(() => {
     win = merge(mocks.createFakeWindow(), mockDocument.getWindowObject());
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   describe('safe frames enabled', () => {
@@ -256,7 +261,7 @@ describe('nativeAssetManager', () => {
       ],null,null);
 
       const nativeAssetManager = makeManager();
-      nativeAssetManager.loadAssets(AD_ID);
+      nativeAssetManager.loadAssets(win.pbNativeData.adId);
 
       expect(win.document.body.innerHTML).to.equal(`<script>
                 let nativeTag = {};
@@ -558,8 +563,9 @@ describe('nativeAssetManager', () => {
       }
     })
 
-    it('should set the iframe to the width of the container', () => {
-      const html = `<script>
+    describe('body width resizing', () => {
+      beforeEach(() => {
+        const html = `<script>
                   let nativeTag = {};
                 nativeTag.adTemplate = "<div class=\"sponsored-post\">\r\n  <div class=\"thumbnail\"><\/div>\r\n  <div class=\"content\">\r\n  <h1>\r\n    <a href=\"##hb_native_linkurl##\" target=\"_blank\" class=\"pb-click\">##hb_native_title##<\/a>\r\n   <\/h1>\r\n    <p>##hb_native_body##<\/p>\r\n    \t<div class=\"attribution\">\r\n                   \t<img class=\"pb-icon\" src=\"##hb_native_image##\" alt=\"icon\" height=\"150\" width=\"50\">\r\n \t\r\n           \t<\/div>\r\n\t<\/div>\r\n<\/div>";
                 nativeTag.pubUrl = "https://www.url.com";
@@ -567,27 +573,51 @@ describe('nativeAssetManager', () => {
                 nativeTag.requestAllAssets = true;
                 window.pbNativeTag.renderNativeAd(nativeTag);
         </script>`;
-      win.pbNativeData = {
-        pubUrl : 'https://www.url.com',
-        adId : AD_ID,
-        adTemplate : '<div class=\"sponsored-post\">\r\n  <div class=\"thumbnail\"><\/div>\r\n  <div class=\"content\">\r\n  <h1>\r\n    <a href=\"##hb_native_linkurl##\" target=\"_blank\" class=\"pb-click\">##hb_native_title##<\/a>\r\n   <\/h1>\r\n    <p>##hb_native_body##<\/p>\r\n    \t<div class=\"attribution\">\r\n                   \t<img class=\"pb-icon\" src=\"##hb_native_image##\" alt=\"icon\" height=\"150\" width=\"50\">\r\n \t\r\n           \t<\/div>\r\n\t<\/div>\r\n<\/div>'
-      };
+        win.pbNativeData = {
+          pubUrl : 'https://www.url.com',
+          adId : AD_ID,
+          adTemplate : '<div class=\"sponsored-post\">\r\n  <div class=\"thumbnail\"><\/div>\r\n  <div class=\"content\">\r\n  <h1>\r\n    <a href=\"##hb_native_linkurl##\" target=\"_blank\" class=\"pb-click\">##hb_native_title##<\/a>\r\n   <\/h1>\r\n    <p>##hb_native_body##<\/p>\r\n    \t<div class=\"attribution\">\r\n                   \t<img class=\"pb-icon\" src=\"##hb_native_image##\" alt=\"icon\" height=\"150\" width=\"50\">\r\n \t\r\n           \t<\/div>\r\n\t<\/div>\r\n<\/div>'
+        };
 
-      win.document.body.innerHTML = html;
-      win.addEventListener = createResponder([
-        { key: 'body', value: 'Body content' },
-        { key: 'title', value: 'new value' },
-        { key: 'clickUrl', value: 'http://www.example.com' },
-        { key: 'image', value: 'http://www.image.com/picture.jpg' },
-      ]);
+        win.document.body.innerHTML = html;
+        win.addEventListener = createResponder([
+          { key: 'body', value: 'Body content' },
+          { key: 'title', value: 'new value' },
+          { key: 'clickUrl', value: 'http://www.example.com' },
+          { key: 'image', value: 'http://www.image.com/picture.jpg' },
+        ]);
+      });
 
-      const nativeAssetManager = makeManager();
-      nativeAssetManager.loadAssets(AD_ID);
+      it('should not choke when parent window is not available',() => {
+        win.parent.frames = [win];
+        Object.defineProperty(win.parent, 'document', {
+          get() {
+            throw new Error('unvailable');
+          }
+        })
+        const nativeAssetManager = makeManager();
+        nativeAssetManager.loadAssets(AD_ID);
+        expect(win.document.body.innerHTML).to.include(`<a href="http://www.example.com" target="_blank" class="pb-click">new value</a>`);
+      });
 
-      expect(win.document.body.innerHTML).to.include(`<a href="http://www.example.com" target="_blank" class="pb-click">new value</a>`);
-      expect(win.document.body.innerHTML).to.include(`<img class="pb-icon" src="http://www.image.com/picture.jpg" alt="icon" height="150" width="50">`);
-      expect(win.document.body.innerHTML).to.include(`<p>Body content</p>`);
-      expect(win.document.body.style.width).to.equal('600px');
+      it('should not request width resize if width is 1', () => {
+        sandbox.stub(document.body, 'clientWidth').get(() => 1);
+        const nativeAssetManager = makeManager();
+        nativeAssetManager.loadAssets(AD_ID);
+        const resizeRequest = win.parent.postMessage.args
+            .map(([msg]) => JSON.parse(msg))
+            .find((msg) => msg.action === 'resizeNativeHeight')
+        expect(resizeRequest.width).to.not.exist;
+      })
+
+      it('should set the iframe to the width of the container', () => {
+        const nativeAssetManager = makeManager();
+        nativeAssetManager.loadAssets(AD_ID);
+        expect(win.document.body.innerHTML).to.include(`<a href="http://www.example.com" target="_blank" class="pb-click">new value</a>`);
+        expect(win.document.body.innerHTML).to.include(`<img class="pb-icon" src="http://www.image.com/picture.jpg" alt="icon" height="150" width="50">`);
+        expect(win.document.body.innerHTML).to.include(`<p>Body content</p>`);
+        expect(win.document.body.style.width).to.equal('600px');
+      });
     });
   });
 


### PR DESCRIPTION
Hey @harpere, here's the proposed fix for the native SafeFrame rendering issue taken from the `1.17.0` version of the PUC.

Despite all tests passing, I'm seeing an error logged when running `gulp test` as documented in [HB-20754](https://magnite.atlassian.net/browse/HB-20754) -- but as this error is also logged in our current `1.16.0` fork, I am assuming it should be okay.