### PR TITLE
HB-21990: Add support for custom Prebid global variable name

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -55,15 +55,18 @@ export function canInspectWindow(win) {
 /**
  * Returns true if we can find the prebid global object (eg pbjs) as we
  * climb the accessible windows.  Return false if it's not found.
+ * @param {Window} win Window object
+ * @param {string} globalName Optional custom global variable name (default: $$PREBID_GLOBAL$$)
  * @returns {boolean}
  */
-export function canLocatePrebid(win) {
+export function canLocatePrebid(win, globalName = '$$PREBID_GLOBAL$$') {
+
   let result = false;
   let currentWindow = win;
 
   while (!result) {
     try {
-      if (currentWindow.$$PREBID_GLOBAL$$) {
+      if (currentWindow[globalName]) {
         result = true;
         break;
       }

--- a/src/renderingManager.js
+++ b/src/renderingManager.js
@@ -6,11 +6,13 @@ import {hasDynamicRenderer, runDynamicRenderer} from './dynamicRenderer.js';
 
 export function renderBannerOrDisplayAd(doc, dataObject) {
   const targetingData = transformAuctionTargetingData(dataObject);
+  // Use custom global name if provided via targeting, otherwise use default
+  const globalName = targetingData.prebidGlobal || '$$PREBID_GLOBAL$$';
 
-  if (!canLocatePrebid(window)) {
+  if (!canLocatePrebid(window, globalName)) {
     renderCrossDomain(window, targetingData.adId, targetingData.adServerDomain, targetingData.pubUrl);
   } else {
-    renderLegacy(doc, targetingData.adId);
+    renderLegacy(doc, targetingData.adId, globalName);
   }
 }
 
@@ -18,15 +20,16 @@ export function renderBannerOrDisplayAd(doc, dataObject) {
  * Calls prebid.js renderAd function to render ad
  * @param {Object} doc Document
  * @param {string} adId Id of creative to render
+ * @param {string} globalName Name of the prebid global variable (default: $$PREBID_GLOBAL$$)
  */
-export function renderLegacy(doc, adId) {
+export function renderLegacy(doc, adId, globalName = '$$PREBID_GLOBAL$$') {
   let found = false;
   let w = window;
   for (let i = 0; i < 10; i++) {
     w = w.parent;
-    if (w.$$PREBID_GLOBAL$$) {
+    if (w[globalName]) {
       try {
-        w.$$PREBID_GLOBAL$$.renderAd(doc, adId);
+        w[globalName].renderAd(doc, adId);
         found = true;
         break;
       } catch (e) {
@@ -35,7 +38,7 @@ export function renderLegacy(doc, adId) {
     }
   }
   if (!found) {
-    console.error("Unable to locate $$PREBID_GLOBAL$$.renderAd function!");
+    console.error(`Unable to locate ${globalName}.renderAd function!`);
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -122,7 +122,8 @@ export function transformAuctionTargetingData(tagData) {
     hb_format: 'mediaType',
     hb_env: 'env',
     hb_size: 'size',
-    hb_pb: 'hbPb'
+    hb_pb: 'hbPb',
+    hb_prebid_global: 'prebidGlobal'  // Support custom Prebid.js global variable name
   };
 
   /**

--- a/test/spec/environment_spec.js
+++ b/test/spec/environment_spec.js
@@ -14,6 +14,20 @@ const envMocks = {
 }
 
 describe('environment module', function() {
+  it('should detect Prebid with custom globalName', function() {
+    // Create a window chain similar to the default test but with custom global
+    let localWindow = {
+      parent: {
+        parent: {
+          myCustomPbjs: {
+            fakeFn: () => {}
+          }
+        }
+      }
+    };
+    const mockWin = merge(mocks.createFakeWindow('http://appnexus.com'), envMocks.getWindowObject(), localWindow);
+    expect(env.canLocatePrebid(mockWin, 'myCustomPbjs')).to.equal(true);
+  });
   
   it('should return env object with proper public api', function() {
     expect(env.isMobileApp).to.exist;
@@ -57,5 +71,3 @@ describe('environment module', function() {
     expect(env.isMobileApp('mobile-app')).to.equal(true);
   });
 });
-
-

--- a/test/spec/renderingManager_spec.js
+++ b/test/spec/renderingManager_spec.js
@@ -221,6 +221,23 @@ describe('renderingManager', function() {
   });
 
   describe('legacy creative', function() {
+        it('should use custom prebidGlobal if provided', function() {
+          const mockWin = merge(mocks.createFakeWindow('http://example.com'), renderingMocks().getWindowObject());
+          let ucTagData = {
+            adId: '123',
+            prebidGlobal: 'myPbjsGlobal'
+          };
+          // Add custom global to parent
+          mockWin.parent.myPbjsGlobal = { renderAd: sinon.spy() };
+          window.parent = mockWin;
+          // Patch canLocatePrebid to return true for custom global
+          const renderingManager = require('src/renderingManager');
+          const origCanLocatePrebid = require('src/environment').canLocatePrebid;
+          require('src/environment').canLocatePrebid = () => true;
+          renderingManager.renderLegacy(mockWin.document, ucTagData.adId, ucTagData.prebidGlobal);
+          expect(mockWin.parent.myPbjsGlobal.renderAd.callCount).to.equal(1);
+          require('src/environment').canLocatePrebid = origCanLocatePrebid;
+        });
     it('should render legacy creative', function() {
       const mockWin = merge(mocks.createFakeWindow('http://example.com'), renderingMocks().getWindowObject());
       let ucTagData = {

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -3,6 +3,17 @@ import * as utils from 'src/utils';
 
 describe('utils', function () {
   describe('transformAuctionTargetingData', function () {
+        it('should map hb_prebid_global to prebidGlobal', function () {
+          let ucTagData = {
+            targetingMap: {
+              hb_prebid_global: ['myPbjs']
+            }
+          };
+          let auctionData = utils.transformAuctionTargetingData(ucTagData);
+          expect(auctionData).to.deep.equal({
+            prebidGlobal: 'myPbjs'
+          });
+        });
     it('should transform non dfp arguments', function () {
       let ucTagData = {
         cacheHost: 'example.com',


### PR DESCRIPTION
- Updated canLocatePrebid and renderLegacy functions to accept an optional custom global variable name.
- Modified renderingManager to use the custom global name if provided in targeting data.
- Enhanced transformAuctionTargetingData to map hb_prebid_global to prebidGlobal.
- Added tests to verify functionality with custom global names in environment and rendering modules.